### PR TITLE
Remove unnecessary checks of allowed-to-use

### DIFF
--- a/index.html
+++ b/index.html
@@ -206,12 +206,6 @@
                 `Document`=].
               </li>
               <li>
-                If |document| is not [=allowed to use=] the
-                <code>"captured-surface-control"</code> feature, return a promise
-                [=reject|rejected=] with a {{DOMException}} object whose {{DOMException/name}}
-                attribute has the value {{NotAllowedError}}.
-              </li>
-              <li>
                 If [=this=] is not [=actively capturing=], return a promise [=reject|rejected=] with
                 a {{DOMException}} object whose {{DOMException/name}} attribute has the value
                 {{InvalidStateError}}.
@@ -326,15 +320,6 @@
           </p>
           <p>When invoked, the user agent MUST run the following steps:</p>
           <ol>
-            <li>
-              Let |document:Document| be the [=relevant global object=]'s [=associated `Document`=].
-            </li>
-            <li>
-              If |document| is not [=allowed to use=] the
-              <code>"captured-surface-control"</code> feature, return a promise [=reject|rejected=]
-              with a {{DOMException}} object whose {{DOMException/name}} attribute has the value
-              {{NotAllowedError}}.
-            </li>
             <li>
               If [=this=] is not [=actively capturing=], return a promise [=reject|rejected=] with a
               {{DOMException}} object whose {{DOMException/name}} attribute has the value


### PR DESCRIPTION
These are not necessary, because both [Request permission to use](https://www.w3.org/TR/permissions/#dfn-request-permission-to-use) and [Get the current permission state](https://www.w3.org/TR/permissions/#dfn-getting-the-current-permission-state) include an implicit check of this nature.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/pull/21.html" title="Last updated on Oct 16, 2024, 12:23 PM UTC (9077cf1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/21/779a40c...9077cf1.html" title="Last updated on Oct 16, 2024, 12:23 PM UTC (9077cf1)">Diff</a>