### PR TITLE
Rephrase captureWheel() to avoid early-exit

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,34 +426,37 @@
                   <code>null</code>.
                 </li>
                 <li>
-                  If [=this=].{{CaptureController/[[CaptureWheelElement]]}} is <code>null</code>,
-                  [=resolve=] |P| and abort these steps.
-                </li>
-                <li>
-                  Set [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} to an [=event
-                  listener=] defined as follows:
-                  <dl>
-                    <dt>type</dt>
-                    <dd><code>wheel</code></dd>
-                    <dt>[=event listener/callback=]</dt>
-                    <dd>
-                      The result of creating a new Web IDL {{EventListener}} instance representing a
-                      reference to a function of one argument of type {{Event}} |event|. This
-                      function executes the [=forward wheel event algorithm=] given [=this=] and
-                      |event|.
-                    </dd>
-                  </dl>
-                </li>
-                <li>
-                  <p>[=Add an event listener=] with:</p>
-                  <ul>
+                  If [=this=].{{CaptureController/[[CaptureWheelElement]]}} is not
+                  <code>null</code>:
+                  <ol>
                     <li>
-                      [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget|.
+                      Set [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} to an [=event
+                      listener=] defined as follows:
+                      <dl>
+                        <dt>type</dt>
+                        <dd><code>wheel</code></dd>
+                        <dt>[=event listener/callback=]</dt>
+                        <dd>
+                          The result of creating a new Web IDL {{EventListener}} instance
+                          representing a reference to a function of one argument of type {{Event}}
+                          |event|. This function executes the [=forward wheel event algorithm=]
+                          given [=this=] and |event|.
+                        </dd>
+                      </dl>
                     </li>
                     <li>
-                      [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as |listener|.
+                      <p>[=Add an event listener=] with:</p>
+                      <ul>
+                        <li>
+                          [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget|.
+                        </li>
+                        <li>
+                          [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as
+                          |listener|.
+                        </li>
+                      </ul>
                     </li>
-                  </ul>
+                  </ol>
                 </li>
                 <li>[=Resolve=] |P|.</li>
               </ol>

--- a/index.html
+++ b/index.html
@@ -407,24 +407,16 @@
                   whose {{DOMException/name}} is {{NotAllowedError}} and abort these steps.
                 </li>
                 <li>
-                  <p>
-                    If [=this=].{{CaptureController/[[CaptureWheelElement]]}} is not
-                    <code>null</code>, [=remove an event listener=] with:
-                  </p>
-                  <ul>
-                    <li>
-                      [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget|.
-                    </li>
-                    <li>
-                      [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as |listener|.
-                    </li>
-                  </ul>
+                  If [=this=].{{CaptureController/[[CaptureWheelElement]]}} is not
+                  <code>null</code>, [=remove an event listener=] with
+                  [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget| and
+                  [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as |listener|.
                 </li>
-                <li>Set [=this=].{{CaptureController/[[CaptureWheelElement]]}} to |element|.</li>
                 <li>
                   Set [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} to
                   <code>null</code>.
                 </li>
+                <li>Set [=this=].{{CaptureController/[[CaptureWheelElement]]}} to |element|.</li>
                 <li>
                   If [=this=].{{CaptureController/[[CaptureWheelElement]]}} is not
                   <code>null</code>:
@@ -445,16 +437,9 @@
                       </dl>
                     </li>
                     <li>
-                      <p>[=Add an event listener=] with:</p>
-                      <ul>
-                        <li>
-                          [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget|.
-                        </li>
-                        <li>
-                          [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as
-                          |listener|.
-                        </li>
-                      </ul>
+                      [=Add an event listener=] with
+                      [=this=].{{CaptureController/[[CaptureWheelElement]]}} as |eventTarget| and
+                      [=this=].{{CaptureController/[[CaptureWheelEventListener]]}} as |listener|.
                     </li>
                   </ol>
                 </li>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/pull/34.html" title="Last updated on Oct 22, 2024, 11:18 AM UTC (7a45c14)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/34/abcba55...7a45c14.html" title="Last updated on Oct 22, 2024, 11:18 AM UTC (7a45c14)">Diff</a>