### PR TITLE
Remove 'extension to window' from spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,9 +257,6 @@ It is arguable that the legitimate use case described above is risky. We argue t
 
 ## Potential future extensions
 
-### Extension from tab-capture to window-capture
-At the moment, the API only supports control of captured tabs. In the future, the API might be extended to allow control of windows.
-
 ### Extension to additional gestures
 At the moment, the API allows forwarding of wheel events. In the future, other gestures might be considered, such as pinch.
 

--- a/index.html
+++ b/index.html
@@ -20,10 +20,6 @@
           Deliver a wheel event over |capturee|'s viewport at coordinates of |capturer|'s choosing.
         </li>
       </ul>
-      <p>
-        Initially, these are only specified for captured [=display surfaces=] of type [=display
-        surface/browser=], but an extension to [=display surface/window=] is considered.
-      </p>
     </section>
 
     <section id="sotd"></section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/pull/37.html" title="Last updated on Oct 25, 2024, 3:36 PM UTC (5263327)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/screen-share/captured-surface-control/37/e69645c...5263327.html" title="Last updated on Oct 25, 2024, 3:36 PM UTC (5263327)">Diff</a>